### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/heroku-postgres.yml
+++ b/.github/workflows/heroku-postgres.yml
@@ -1,5 +1,7 @@
 # .github/workflows/heroku-postgres.yml
 name: Deploy Postgres DB to Heroku
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ajharris/knock-em-dead-resume/security/code-scanning/5](https://github.com/ajharris/knock-em-dead-resume/security/code-scanning/5)

To fix this issue, add a `permissions` block at the root of the workflow YAML, specifying the minimal needed privilege. For this workflow, `contents: read` is enough since it just needs to check out code and run migrations; it does not need to modify repository contents or interact with issues/pull requests. Place the `permissions:` key immediately after the `name:` entry (i.e., before `on:`) for clarity and scope.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
